### PR TITLE
[ci skip] adding user @mmcauliffe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,4 +43,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - mmcauliffe
     - mcernak


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @mmcauliffe as instructed in #11.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #11